### PR TITLE
Allow Wayland socket access to fix initialization error

### DIFF
--- a/com.zettlr.Zettlr.yaml
+++ b/com.zettlr.Zettlr.yaml
@@ -9,7 +9,8 @@ command: start-zettlr
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
Fixes an issue where the app fails to initialize on wayland setups.